### PR TITLE
Reflect OS level differences in requirements and install paths

### DIFF
--- a/.github/workflows/release_snapshot.yml
+++ b/.github/workflows/release_snapshot.yml
@@ -107,13 +107,13 @@ jobs:
           python-version: 3.8
       - run: |
           export CREATED_TAG="${{ needs.linux-create.outputs.created_tag }}"
-          python -m pip install --user --upgrade pip
+          python -m pip --upgrade pip
           curl --fail --retry 15 --retry-all-errors -OL https://github.com/dbt-labs/dbt-core-snapshots/releases/download/$CREATED_TAG/snapshot_core_all_adapters_linux_3.8.zip
           curl --fail --retry 15 --retry-all-errors -OL https://github.com/dbt-labs/dbt-core-snapshots/releases/download/$CREATED_TAG/snapshot_requirements_linux_3.8.txt
           tail -n 200 snapshot_requirements_linux_3.8.txt
           unzip snapshot_core_all_adapters_linux_3.8.zip -d snapshot_pkgs
           pip install -r snapshot_requirements_linux_3.8.txt \
-              --no-index \ 
-              --find-links ./snapshot_pkgs \
-              && \
-              pip freeze
+            --no-index \
+            --find-links ./snapshot_pkgs \
+            && \
+            pip freeze

--- a/.github/workflows/release_snapshot.yml
+++ b/.github/workflows/release_snapshot.yml
@@ -37,10 +37,10 @@ jobs:
       created_tag: ${{ steps.create-release.outputs.created_tag }}
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: 3.8
       - run: |
           sudo apt-get install libsasl2-dev
           python -m pip install --user --upgrade pip
@@ -50,7 +50,6 @@ jobs:
           python release_creation/main.py \
            --input-version=${{ inputs.version_number }} \
            --operation=create
-          tail -n1 result.env
           source ./result.env
           echo "$CREATED_TAG" 
           echo "created_tag=$CREATED_TAG" >> $GITHUB_OUTPUT
@@ -59,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.9", "3.10"]
     env:
       GH_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/release_snapshot.yml
+++ b/.github/workflows/release_snapshot.yml
@@ -107,11 +107,10 @@ jobs:
         with:
           python-version: 3.8
       - run: |
-          echo "${{ needs.linux-create.outputs.created_tag }}"
           export CREATED_TAG="${{ needs.linux-create.outputs.created_tag }}"
           python -m pip install --user --upgrade pip
           curl -OL https://github.com/dbt-labs/dbt-core-snapshots/releases/download/$CREATED_TAG/snapshot_core_all_adapters_linux_3.8.zip
-          curl -OL https://github.com/dbt-labs/dbt-core-snapshots/releases/download/$CREATED_TAG/snapshot_requirements_3.8.txt
+          curl -OL https://github.com/dbt-labs/dbt-core-snapshots/releases/download/$CREATED_TAG/snapshot_requirements_linux_3.8.txt
           unzip snapshot_core_all_adapters_linux_3.8.zip -d snapshot_pkgs
           pip install -r snapshot_requirements_3.8.txt \
               --no-index \ 

--- a/.github/workflows/release_snapshot.yml
+++ b/.github/workflows/release_snapshot.yml
@@ -107,7 +107,7 @@ jobs:
           python-version: 3.8
       - run: |
           export CREATED_TAG="${{ needs.linux-create.outputs.created_tag }}"
-          python -m pip --upgrade pip
+          python -m pip install --user --upgrade pip
           curl --fail --retry 15 --retry-all-errors -OL https://github.com/dbt-labs/dbt-core-snapshots/releases/download/$CREATED_TAG/snapshot_core_all_adapters_linux_3.8.zip
           curl --fail --retry 15 --retry-all-errors -OL https://github.com/dbt-labs/dbt-core-snapshots/releases/download/$CREATED_TAG/snapshot_requirements_linux_3.8.txt
           tail -n 200 snapshot_requirements_linux_3.8.txt

--- a/.github/workflows/release_snapshot.yml
+++ b/.github/workflows/release_snapshot.yml
@@ -107,6 +107,7 @@ jobs:
           python-version: 3.8
       - run: |
           export CREATED_TAG="${{ needs.linux-create.outputs.created_tag }}"
+          export DBT_PSYCOPG2_NAME=psycopg2
           python -m pip install --user --upgrade pip
           curl --fail --retry 15 --retry-all-errors -OL https://github.com/dbt-labs/dbt-core-snapshots/releases/download/$CREATED_TAG/snapshot_core_all_adapters_linux_3.8.zip
           curl --fail --retry 15 --retry-all-errors -OL https://github.com/dbt-labs/dbt-core-snapshots/releases/download/$CREATED_TAG/snapshot_requirements_linux_3.8.txt

--- a/.github/workflows/release_snapshot.yml
+++ b/.github/workflows/release_snapshot.yml
@@ -109,10 +109,11 @@ jobs:
       - run: |
           export CREATED_TAG="${{ needs.linux-create.outputs.created_tag }}"
           python -m pip install --user --upgrade pip
-          curl -OL https://github.com/dbt-labs/dbt-core-snapshots/releases/download/$CREATED_TAG/snapshot_core_all_adapters_linux_3.8.zip
-          curl -OL https://github.com/dbt-labs/dbt-core-snapshots/releases/download/$CREATED_TAG/snapshot_requirements_linux_3.8.txt
+          curl --fail --retry 15 --retry-all-errors -OL https://github.com/dbt-labs/dbt-core-snapshots/releases/download/$CREATED_TAG/snapshot_core_all_adapters_linux_3.8.zip
+          curl --fail --retry 15 --retry-all-errors -OL https://github.com/dbt-labs/dbt-core-snapshots/releases/download/$CREATED_TAG/snapshot_requirements_linux_3.8.txt
+          tail -n 200 snapshot_requirements_linux_3.8.txt
           unzip snapshot_core_all_adapters_linux_3.8.zip -d snapshot_pkgs
-          pip install -r snapshot_requirements_3.8.txt \
+          pip install -r snapshot_requirements_linux_3.8.txt \
               --no-index \ 
               --find-links ./snapshot_pkgs \
               && \

--- a/release_creation/main.py
+++ b/release_creation/main.py
@@ -1,8 +1,7 @@
-from distutils.version import Version
 import logging
 from strenum import StrEnum
 import os
-import sys
+from semantic_version.base import Version
 import argparse
 
 from github_client.releases import (
@@ -47,7 +46,7 @@ def main():
         logger.info(f"Attempting to create new release for target version: {target_version}")
         logger.info(f"release assets {[]}")
         create_new_release_for_version(target_version, snapshot_assets, latest_release)
-        write_result(version=version)
+        write_result(version=target_version)
     elif operation == ReleaseOperations.update:
         snapshot_assets = generate_snapshot(latest_version)
         add_assets_to_release(assets=snapshot_assets, latest_release=latest_release)        

--- a/release_creation/snapshot/create.py
+++ b/release_creation/snapshot/create.py
@@ -22,9 +22,9 @@ def _get_local_os() -> str:
 
 def _get_extra_platforms_for_os(_os: str) -> List[str]:
     if _os == "mac":
-        return ['macosx_10_9_x86_64', 'macosx_11_0_arm64']
+        return ['macosx_10_9_x86_64', 'macosx_11_0_arm64', 'macosx_10_10_intel', 'macosx_12_0_arm64']
     else:
-        return ['manylinux_2_17_x86_64','manylinux2014_x86_64']
+        return ['manylinux_2_17_x86_64','manylinux2014_x86_64', 'manylinux2014_i686']
 
 
 def _get_requirements_prefix(

--- a/release_creation/snapshot/create.py
+++ b/release_creation/snapshot/create.py
@@ -100,6 +100,6 @@ def generate_snapshot(target_version: Version) -> Dict[str, str]:
 
     assets = {}
     assets[f"snapshot_core_all_adapters_{local_os}_{py_major_minor}.zip"] = py_version_archive_path + ".zip"
-    assets[f"{SNAPSHOT_REQ_NAME_PREFIX}_{py_major_minor}.txt"] = requirements_file
+    assets[f"{SNAPSHOT_REQ_NAME_PREFIX}_{local_os}_{py_major_minor}.txt"] = requirements_file
 
     return assets

--- a/release_creation/snapshot/download_no_deps.sh
+++ b/release_creation/snapshot/download_no_deps.sh
@@ -1,3 +1,4 @@
+#!/bin/bash -e
 set -e
 final_dest=$1
 platform=$2
@@ -9,5 +10,14 @@ pip download -r $requirements_file \
  --progress-bar off \
  --platform $platform \
  --no-deps
+
+# some mac builds needs wheel and cython installed
+if [[ "$OSTYPE" == darwin* ]]; then 
+    pip download wheel cython \
+    --dest $staging \
+    --progress-bar off \
+    --platform $platform \
+    --no-deps
+fi
 
 cp -a $staging/. $final_dest/

--- a/release_creation/snapshot/download_no_deps.sh
+++ b/release_creation/snapshot/download_no_deps.sh
@@ -12,8 +12,9 @@ pip download -r $requirements_file \
  --no-deps
 
 # some mac builds needs wheel and cython installed
+# include the psycopg2-binary in mac builds for ease of install
 if [[ "$OSTYPE" == darwin* ]]; then 
-    pip download wheel cython \
+    pip download wheel cython psycopg2-binary==2.9.5 \
     --dest $staging \
     --progress-bar off \
     --platform $platform \


### PR DESCRIPTION
This PR includes a number of overlapping changes:
* Create snapshot_requirments.txt per OS (i.e. mac / linux )
* Test linux install for py 3.8

Not included:
* testing all py/OS combinations