### PR TITLE
add dbt-trino to pre and add 1.4.latest requirements file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,10 @@ MANIFEST
 *.manifest
 *.spec
 
+#pycharm
+.idea
+.idea/*
+
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt

--- a/release_creation/snapshot/requirements/v1.1.pre.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.1.pre.requirements.txt
@@ -5,6 +5,7 @@ dbt-redshift~=1.1.0b1
 dbt-postgres~=1.1.0b1
 dbt-spark[PyHive,ODBC]~=1.1.0b1
 dbt-databricks~=1.1.5
+dbt-trino~=1.1.0
 dbt-rpc~=0.1.0b1
 grpcio-status~=1.47.0
 pyasn1-modules~=0.2.1

--- a/release_creation/snapshot/requirements/v1.2.pre.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.2.pre.requirements.txt
@@ -5,6 +5,7 @@ dbt-redshift~=1.2.0b1
 dbt-postgres~=1.2.0b1
 dbt-spark[PyHive,ODbC]~=1.2.0b1
 dbt-databricks==1.2.3
+dbt-trino~=1.2.0
 dbt-rpc~=0.1.1
 grpcio-status~=1.47.0
 pyasn1-modules~=0.2.1

--- a/release_creation/snapshot/requirements/v1.3.pre.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.3.pre.requirements.txt
@@ -5,6 +5,7 @@ dbt-redshift~=1.3.0b1
 dbt-postgres~=1.3.0b1
 dbt-spark[PyHive,ODBC]~=1.3.0b1
 dbt-databricks~=1.3.0
+dbt-trino~=1.3.0
 dbt-rpc~=0.1.1
 grpcio-status~=1.47.0
 pyasn1-modules~=0.2.1

--- a/release_creation/snapshot/requirements/v1.4.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.4.latest.requirements.txt
@@ -1,0 +1,12 @@
+dbt-core~=1.4.0 --no-binary dbt-postgres
+dbt-snowflake~=1.4.0
+dbt-bigquery~=1.4.0
+dbt-redshift~=1.4.0
+dbt-postgres~=1.4.0
+dbt-spark[PyHive,ODBC]~=1.4.0
+dbt-databricks~=1.4.0
+dbt-databricks~=1.4.0
+dbt-rpc~=0.1.1
+grpcio-status~=1.47.0
+pyasn1-modules~=0.2.1
+pyodbc==4.0.32 --no-binary pyodbc

--- a/release_creation/snapshot/requirements/v1.4.pre.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.4.pre.requirements.txt
@@ -4,7 +4,8 @@ dbt-bigquery~=1.4.0rc1
 dbt-redshift~=1.4.0rc1
 dbt-postgres~=1.4.0rc1
 dbt-spark[PyHive,ODBC]~=1.4.0rc1
-# dbt-databricks==1.4.0rc1 Unavailable
+dbt-databricks~=1.4.0
+dbt-trino~=1.4.0
 dbt-rpc~=0.1.1
 grpcio-status~=1.47.0
 pyasn1-modules~=0.2.1


### PR DESCRIPTION
Updating snapshots requirements to include dbt-trino in "pre" snapshots and add a requirement file 1.4.latest