### PR TITLE
Update for 1.5.0 release

### DIFF
--- a/.github/workflows/scheduled_releases.yml
+++ b/.github/workflows/scheduled_releases.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
        # we support the trailing four versions plus the latest pre-release
        # and the upcoming version's pre-release.
-       version: ["1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.4.0b1", "1.5.0b1"]
+       version: ["1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.4.0b1", "1.5.0b1", "1.5.0"]
     name: Call Release Workflow for ${{ matrix.version }}
     uses: ./.github/workflows/release_bundle.yml
     with:

--- a/release_creation/snapshot/requirements/v1.5.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.5.latest.requirements.txt
@@ -1,0 +1,12 @@
+dbt-core~=1.4.0 --no-binary dbt-postgres
+dbt-snowflake~=1.5.0
+dbt-bigquery~=1.5.0
+dbt-redshift~=1.5.0
+dbt-postgres~=1.5.0
+dbt-spark[PyHive,ODBC]~=1.5.0
+dbt-databricks~=1.5.0
+dbt-trino~=1.5.0
+dbt-rpc~=0.1.1
+grpcio-status~=1.47.0
+pyasn1-modules~=0.2.1
+pyodbc==4.0.32 --no-binary pyodbc

--- a/release_creation/snapshot/requirements/v1.5.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.5.latest.requirements.txt
@@ -1,4 +1,4 @@
-dbt-core~=1.4.0 --no-binary dbt-postgres
+dbt-core~=1.5.0 --no-binary dbt-postgres
 dbt-snowflake~=1.5.0
 dbt-bigquery~=1.5.0
 dbt-redshift~=1.5.1
@@ -6,7 +6,7 @@ dbt-postgres~=1.5.0
 dbt-spark[PyHive,ODBC]~=1.5.0
 dbt-databricks~=1.5.0
 dbt-trino~=1.5.0
-dbt-rpc~=0.1.1
+dbt-rpc~=0.4.1
 grpcio-status~=1.47.0
 pyasn1-modules~=0.2.1
 pyodbc==4.0.32 --no-binary pyodbc

--- a/release_creation/snapshot/requirements/v1.5.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.5.latest.requirements.txt
@@ -6,7 +6,7 @@ dbt-postgres~=1.5.0
 dbt-spark[PyHive,ODBC]~=1.5.0
 dbt-databricks~=1.5.0
 dbt-trino~=1.5.0
-dbt-rpc~=0.4.1
+dbt-rpc~=0.4.0
 grpcio-status~=1.47.0
 pyasn1-modules~=0.2.1
 pyodbc==4.0.32 --no-binary pyodbc

--- a/release_creation/snapshot/requirements/v1.5.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.5.latest.requirements.txt
@@ -1,7 +1,7 @@
 dbt-core~=1.4.0 --no-binary dbt-postgres
 dbt-snowflake~=1.5.0
 dbt-bigquery~=1.5.0
-dbt-redshift~=1.5.0
+dbt-redshift~=1.5.1
 dbt-postgres~=1.5.0
 dbt-spark[PyHive,ODBC]~=1.5.0
 dbt-databricks~=1.5.0

--- a/test/integration/snapshot/test_create.py
+++ b/test/integration/snapshot/test_create.py
@@ -9,7 +9,7 @@ import zipfile
 
 
 @pytest.mark.parametrize(argnames="test_version",
-                         argvalues=["1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0b1"])
+                         argvalues=["1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0b1", "1.5.0"])
 def test_generate_snapshot_creates_a_snapshot_with_valid_version(test_version):
     created_assets = generate_snapshot(Version.coerce(test_version))
     for asset_name, asset_location in created_assets.items():


### PR DESCRIPTION
Updated the requirements.txt for the 1.5.latest versions.
Note: redshift is pointing to 1.5.1 due to a regression that was patched in 1.5.0