### PR TITLE
Fix failing integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
        os: ["macos-latest", "ubuntu-latest"]
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.8"
 
       - name: Set up Linux
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -42,10 +42,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install libsasl2-dev
 
-      - name: Run Unit Tests
+      - name: Python setup
         run: |
+          python -m pip install --upgrade pip
           python -m pip install tox
-          tox
+      
+      - name: Run Unit Tests
+        run: tox
 
       - name: Run Integration Tests
+        # run integration tests even when unit tests fail
+        if: ${{ always() }}
         run: tox -e integration

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.8"
 
       - name: Set up Linux
         if: matrix.os == 'ubuntu-latest'
@@ -46,8 +46,6 @@ jobs:
       - name: Python setup
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade distlib
-          python -m pip install --upgrade setuptools
           python -m pip install tox
       
       - name: Run Unit Tests

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -48,7 +48,7 @@ jobs:
           python -m pip install tox
       
       - name: Run Unit Tests
-        run: tox
+        run: tox -e unit
 
       - name: Run Integration Tests
         # run integration tests even when unit tests fail

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
        os: ["macos-latest", "ubuntu-latest"]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} Test
 
     steps:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: Set up Linux
         if: matrix.os == 'ubuntu-latest'
@@ -46,14 +46,14 @@ jobs:
       - name: Python setup
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade setuptools
           python -m pip install --upgrade distlib
+          python -m pip install --upgrade setuptools
           python -m pip install tox
       
       - name: Run Unit Tests
         run: tox -e unit
 
-      - name: Run Integration Tests
+      - name: Run Integration Tests (long running)
         # run integration tests even when unit tests fail
         if: ${{ always() }}
         run: tox -e integration

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -45,6 +45,8 @@ jobs:
       - name: Python setup
         run: |
           python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools
+          python -m pip install --upgrade distlib
           python -m pip install tox
       
       - name: Run Unit Tests

--- a/.gitignore
+++ b/.gitignore
@@ -74,7 +74,7 @@ __pypackages__/
 # Environments
 .env
 .venv
-env/
+env*/
 venv/
 ENV/
 env.bak/

--- a/test/unit/snapshot/test_snapshot_config.py
+++ b/test/unit/snapshot/test_snapshot_config.py
@@ -5,7 +5,7 @@ from release_creation.snapshot.snapshot_config import get_snapshot_config
 
 
 @pytest.mark.parametrize(argnames="test_input",
-                         argvalues=[("1.1.0", False), ("1.5.0", True)])
+                         argvalues=[("1.1.0", False), ("1.1.0b1", True)])
 def test_get_snapshot_config_returns_valid_object(test_input):
     is_pre = test_input[1]
     test_version = Version.coerce(test_input[0])

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
   -rtest/test_requirements.txt
 
 [testenv:{integration,py37,py38,py39,py310,py311,py}]
-description = unit testing
+description = integration testing
 skip_install = true
 passenv =
     DBT_*


### PR DESCRIPTION
Integration tests are currently failing.  This fixes the failing tests.

**_Tests will still fail on this PR because it uses pull_request_target so it's going to be using the workflow on `main`._**

Manual workflow run to show tests are passing: https://github.com/dbt-labs/dbt-core-snapshots/actions/runs/5082665655