### PR TITLE
Force pin snowflake-connector-python

### DIFF
--- a/release_creation/snapshot/requirements/v1.0.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.0.latest.requirements.txt
@@ -1,5 +1,6 @@
 dbt-core~=1.0.0  --no-binary dbt-postgres
 dbt-snowflake~=1.0.0
+snowlake-connector-python~=3.0,!=3.0.4
 dbt-bigquery~=1.0.0
 dbt-redshift~=1.0.0
 dbt-postgres~=1.0.0

--- a/release_creation/snapshot/requirements/v1.0.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.0.latest.requirements.txt
@@ -1,6 +1,5 @@
 dbt-core~=1.0.0  --no-binary dbt-postgres
 dbt-snowflake~=1.0.0
-snowflake-connector-python~=3.0,!=3.0.4
 dbt-bigquery~=1.0.0
 dbt-redshift~=1.0.0
 dbt-postgres~=1.0.0
@@ -10,3 +9,4 @@ dbt-rpc~=0.1.1
 grpcio-status~=1.47.0
 pyasn1-modules~=0.2.1
 pyodbc~=4.0.32
+snowflake-connector-python~=3.0,!=3.0.4

--- a/release_creation/snapshot/requirements/v1.0.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.0.latest.requirements.txt
@@ -1,6 +1,6 @@
 dbt-core~=1.0.0  --no-binary dbt-postgres
 dbt-snowflake~=1.0.0
-snowlake-connector-python~=3.0,!=3.0.4
+snowflake-connector-python~=3.0,!=3.0.4
 dbt-bigquery~=1.0.0
 dbt-redshift~=1.0.0
 dbt-postgres~=1.0.0

--- a/release_creation/snapshot/requirements/v1.1.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.1.latest.requirements.txt
@@ -1,6 +1,5 @@
 dbt-core~=1.1.0  --no-binary dbt-postgres
 dbt-snowflake~=1.1.0
-snowflake-connector-python~=3.0,!=3.0.4
 dbt-bigquery~=1.1.0
 dbt-redshift~=1.1.0
 dbt-postgres~=1.1.0
@@ -10,4 +9,5 @@ dbt-rpc~=0.1.1
 grpcio-status~=1.47.0
 pyasn1-modules~=0.2.1
 pyodbc~=4.0.32
+snowflake-connector-python~=3.0,!=3.0.4
 wheel

--- a/release_creation/snapshot/requirements/v1.1.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.1.latest.requirements.txt
@@ -1,5 +1,6 @@
 dbt-core~=1.1.0  --no-binary dbt-postgres
 dbt-snowflake~=1.1.0
+snowlake-connector-python~=3.0,!=3.0.4
 dbt-bigquery~=1.1.0
 dbt-redshift~=1.1.0
 dbt-postgres~=1.1.0

--- a/release_creation/snapshot/requirements/v1.1.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.1.latest.requirements.txt
@@ -1,6 +1,6 @@
 dbt-core~=1.1.0  --no-binary dbt-postgres
 dbt-snowflake~=1.1.0
-snowlake-connector-python~=3.0,!=3.0.4
+snowflake-connector-python~=3.0,!=3.0.4
 dbt-bigquery~=1.1.0
 dbt-redshift~=1.1.0
 dbt-postgres~=1.1.0

--- a/release_creation/snapshot/requirements/v1.1.pre.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.1.pre.requirements.txt
@@ -10,4 +10,5 @@ dbt-rpc~=0.1.0b1
 grpcio-status~=1.47.0
 pyasn1-modules~=0.2.1
 pyodbc~=4.0.32
+snowflake-connector-python~=3.0,!=3.0.4
 wheel

--- a/release_creation/snapshot/requirements/v1.2.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.2.latest.requirements.txt
@@ -1,6 +1,5 @@
 dbt-core~=1.2.0 --no-binary dbt-postgres
 dbt-snowflake~=1.2.0
-snowflake-connector-python~=3.0,!=3.0.4
 dbt-bigquery~=1.2.0
 dbt-redshift~=1.2.0
 dbt-postgres~=1.2.0
@@ -10,3 +9,4 @@ dbt-rpc~=0.1.1
 grpcio-status~=1.47.0
 pyasn1-modules~=0.2.1
 pyodbc==4.0.32 --no-binary pyodbc
+snowflake-connector-python~=3.0,!=3.0.4

--- a/release_creation/snapshot/requirements/v1.2.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.2.latest.requirements.txt
@@ -1,6 +1,6 @@
 dbt-core~=1.2.0 --no-binary dbt-postgres
 dbt-snowflake~=1.2.0
-snowlake-connector-python~=3.0,!=3.0.4
+snowflake-connector-python~=3.0,!=3.0.4
 dbt-bigquery~=1.2.0
 dbt-redshift~=1.2.0
 dbt-postgres~=1.2.0

--- a/release_creation/snapshot/requirements/v1.2.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.2.latest.requirements.txt
@@ -1,5 +1,6 @@
 dbt-core~=1.2.0 --no-binary dbt-postgres
 dbt-snowflake~=1.2.0
+snowlake-connector-python~=3.0,!=3.0.4
 dbt-bigquery~=1.2.0
 dbt-redshift~=1.2.0
 dbt-postgres~=1.2.0

--- a/release_creation/snapshot/requirements/v1.2.pre.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.2.pre.requirements.txt
@@ -10,3 +10,4 @@ dbt-rpc~=0.1.1
 grpcio-status~=1.47.0
 pyasn1-modules~=0.2.1
 pyodbc==4.0.32 --no-binary pyodbc
+snowflake-connector-python~=3.0,!=3.0.4

--- a/release_creation/snapshot/requirements/v1.3.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.3.latest.requirements.txt
@@ -1,6 +1,6 @@
 dbt-core~=1.3.0 --no-binary dbt-postgres
 dbt-snowflake~=1.3.0
-snowlake-connector-python~=3.0,!=3.0.4
+snowflake-connector-python~=3.0,!=3.0.4
 dbt-bigquery~=1.3.0
 dbt-redshift~=1.3.0
 dbt-postgres~=1.3.0

--- a/release_creation/snapshot/requirements/v1.3.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.3.latest.requirements.txt
@@ -1,5 +1,6 @@
 dbt-core~=1.3.0 --no-binary dbt-postgres
 dbt-snowflake~=1.3.0
+snowlake-connector-python~=3.0,!=3.0.4
 dbt-bigquery~=1.3.0
 dbt-redshift~=1.3.0
 dbt-postgres~=1.3.0

--- a/release_creation/snapshot/requirements/v1.3.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.3.latest.requirements.txt
@@ -1,6 +1,5 @@
 dbt-core~=1.3.0 --no-binary dbt-postgres
 dbt-snowflake~=1.3.0
-snowflake-connector-python~=3.0,!=3.0.4
 dbt-bigquery~=1.3.0
 dbt-redshift~=1.3.0
 dbt-postgres~=1.3.0
@@ -10,3 +9,4 @@ dbt-rpc~=0.1.1
 grpcio-status~=1.47.0
 pyasn1-modules~=0.2.1
 pyodbc==4.0.32 --no-binary pyodbc
+snowflake-connector-python~=3.0,!=3.0.4

--- a/release_creation/snapshot/requirements/v1.3.pre.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.3.pre.requirements.txt
@@ -10,3 +10,4 @@ dbt-rpc~=0.1.1 --pre
 grpcio-status~=1.47.0
 pyasn1-modules~=0.2.1
 pyodbc==4.0.32 --no-binary pyodbc
+snowflake-connector-python~=3.0,!=3.0.4

--- a/release_creation/snapshot/requirements/v1.4.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.4.latest.requirements.txt
@@ -3,7 +3,7 @@
 setuptools~=40.8.0
 dbt-core~=1.4.0 --no-binary dbt-postgres
 dbt-snowflake~=1.4.0
-snowlake-connector-python~=3.0,!=3.0.4
+snowflake-connector-python~=3.0,!=3.0.4
 dbt-bigquery~=1.4.0
 dbt-redshift~=1.4.0
 dbt-postgres~=1.4.0

--- a/release_creation/snapshot/requirements/v1.4.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.4.latest.requirements.txt
@@ -3,7 +3,6 @@
 setuptools~=40.8.0
 dbt-core~=1.4.0 --no-binary dbt-postgres
 dbt-snowflake~=1.4.0
-snowflake-connector-python~=3.0,!=3.0.4
 dbt-bigquery~=1.4.0
 dbt-redshift~=1.4.0
 dbt-postgres~=1.4.0
@@ -14,3 +13,4 @@ dbt-rpc~=0.1.1
 grpcio-status~=1.47.0
 pyasn1-modules~=0.2.1
 pyodbc==4.0.32 --no-binary pyodbc
+snowflake-connector-python~=3.0,!=3.0.4

--- a/release_creation/snapshot/requirements/v1.4.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.4.latest.requirements.txt
@@ -3,6 +3,7 @@
 setuptools~=40.8.0
 dbt-core~=1.4.0 --no-binary dbt-postgres
 dbt-snowflake~=1.4.0
+snowlake-connector-python~=3.0,!=3.0.4
 dbt-bigquery~=1.4.0
 dbt-redshift~=1.4.0
 dbt-postgres~=1.4.0

--- a/release_creation/snapshot/requirements/v1.4.pre.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.4.pre.requirements.txt
@@ -14,3 +14,4 @@ dbt-rpc~=0.1.3b1
 grpcio-status~=1.47.0
 pyasn1-modules~=0.2.1
 pyodbc==4.0.32 --no-binary pyodbc
+snowflake-connector-python~=3.0,!=3.0.4

--- a/release_creation/snapshot/requirements/v1.5.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.5.latest.requirements.txt
@@ -1,6 +1,6 @@
 dbt-core~=1.5.0 --no-binary dbt-postgres
 dbt-snowflake~=1.5.0
-snowlake-connector-python~=3.0,!=3.0.4
+snowflake-connector-python~=3.0,!=3.0.4
 dbt-bigquery~=1.5.0
 dbt-redshift~=1.5.1
 dbt-postgres~=1.5.0

--- a/release_creation/snapshot/requirements/v1.5.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.5.latest.requirements.txt
@@ -1,5 +1,6 @@
 dbt-core~=1.5.0 --no-binary dbt-postgres
 dbt-snowflake~=1.5.0
+snowlake-connector-python~=3.0,!=3.0.4
 dbt-bigquery~=1.5.0
 dbt-redshift~=1.5.1
 dbt-postgres~=1.5.0

--- a/release_creation/snapshot/requirements/v1.5.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.5.latest.requirements.txt
@@ -1,6 +1,5 @@
 dbt-core~=1.5.0 --no-binary dbt-postgres
 dbt-snowflake~=1.5.0
-snowflake-connector-python~=3.0,!=3.0.4
 dbt-bigquery~=1.5.0
 dbt-redshift~=1.5.1
 dbt-postgres~=1.5.0
@@ -11,3 +10,4 @@ dbt-rpc~=0.4.0
 grpcio-status~=1.47.0
 pyasn1-modules~=0.2.1
 pyodbc==4.0.32 --no-binary pyodbc
+snowflake-connector-python~=3.0,!=3.0.4

--- a/release_creation/snapshot/requirements/v1.5.pre.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.5.pre.requirements.txt
@@ -9,3 +9,4 @@ dbt-rpc~=0.1.3b1
 grpcio-status~=1.47.0
 pyasn1-modules~=0.2.1
 pyodbc==4.0.32 --no-binary pyodbc
+snowflake-connector-python~=3.0,!=3.0.4


### PR DESCRIPTION
Pin `snowflake-adapter-python` to _not_ include version 3.0.4 for now.