### PR TITLE
remove patch version specification for dbt-redshift

### DIFF
--- a/release_creation/snapshot/requirements/v1.5.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.5.latest.requirements.txt
@@ -1,7 +1,7 @@
 dbt-core~=1.5.0 --no-binary dbt-postgres
 dbt-snowflake~=1.5.0
 dbt-bigquery~=1.5.0
-dbt-redshift~=1.5.1
+dbt-redshift~=1.5.0
 dbt-postgres~=1.5.0
 dbt-spark[PyHive,ODBC]~=1.5.0
 dbt-databricks~=1.5.0


### PR DESCRIPTION
remove patch version specification for dbt-redshift so we always pull in the latest available when generating the bundles.