### PR TITLE
Address PyArrow package metadata issue

### DIFF
--- a/release_creation/snapshot/create.py
+++ b/release_creation/snapshot/create.py
@@ -12,7 +12,8 @@ def _get_extra_platforms_for_os(_os: str) -> List[str]:
     if _os == "mac":
         return ['macosx_10_9_x86_64', 'macosx_11_0_arm64', 'macosx_10_10_intel', 'macosx_12_0_arm64']
     else:
-        return ['manylinux_2_17_x86_64', 'manylinux2014_x86_64', 'manylinux2014_i686']
+        return ['manylinux_2_17_x86_64', 'manylinux2014_x86_64', 'manylinux2014_i686',
+                'manylinux_2_17_aarch64', 'manylinux2014_aarch64']
 
 
 def _get_requirements_prefix(

--- a/release_creation/snapshot/requirements/v1.1.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.1.latest.requirements.txt
@@ -7,6 +7,7 @@ dbt-spark[PyHive,ODBC]~=1.1.0
 dbt-databricks~=1.1.0
 dbt-rpc~=0.1.1
 grpcio-status~=1.47.0
+pyarrow~=12.0.0,!=12.0.1
 pyasn1-modules~=0.2.1
 pyodbc~=4.0.32
 snowflake-connector-python~=3.0,!=3.0.4

--- a/release_creation/snapshot/requirements/v1.1.pre.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.1.pre.requirements.txt
@@ -8,6 +8,7 @@ dbt-databricks~=1.1.5
 dbt-trino~=1.1.0
 dbt-rpc~=0.1.0b1
 grpcio-status~=1.47.0
+pyarrow~=12.0.0,!=12.0.1
 pyasn1-modules~=0.2.1
 pyodbc~=4.0.32
 snowflake-connector-python~=3.0,!=3.0.4

--- a/release_creation/snapshot/requirements/v1.2.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.2.latest.requirements.txt
@@ -7,6 +7,7 @@ dbt-spark[PyHive,ODBC]~=1.2.0
 dbt-databricks==1.2.3
 dbt-rpc~=0.1.1
 grpcio-status~=1.47.0
+pyarrow~=12.0.0,!=12.0.1
 pyasn1-modules~=0.2.1
 pyodbc==4.0.32 --no-binary pyodbc
 snowflake-connector-python~=3.0,!=3.0.4

--- a/release_creation/snapshot/requirements/v1.2.pre.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.2.pre.requirements.txt
@@ -8,6 +8,7 @@ dbt-databricks==1.2.3
 dbt-trino~=1.2.0
 dbt-rpc~=0.1.1
 grpcio-status~=1.47.0
+pyarrow~=12.0.0,!=12.0.1
 pyasn1-modules~=0.2.1
 pyodbc==4.0.32 --no-binary pyodbc
 snowflake-connector-python~=3.0,!=3.0.4

--- a/release_creation/snapshot/requirements/v1.3.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.3.latest.requirements.txt
@@ -7,6 +7,7 @@ dbt-spark[PyHive,ODBC]~=1.3.0
 dbt-databricks~=1.3.0
 dbt-rpc~=0.1.1
 grpcio-status~=1.47.0
+pyarrow~=12.0.0,!=12.0.1
 pyasn1-modules~=0.2.1
 pyodbc==4.0.32 --no-binary pyodbc
 snowflake-connector-python~=3.0,!=3.0.4

--- a/release_creation/snapshot/requirements/v1.3.pre.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.3.pre.requirements.txt
@@ -8,6 +8,7 @@ dbt-databricks~=1.3.0
 dbt-trino~=1.3.0
 dbt-rpc~=0.1.1 --pre
 grpcio-status~=1.47.0
+pyarrow~=12.0.0,!=12.0.1
 pyasn1-modules~=0.2.1
 pyodbc==4.0.32 --no-binary pyodbc
 snowflake-connector-python~=3.0,!=3.0.4

--- a/release_creation/snapshot/requirements/v1.4.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.4.latest.requirements.txt
@@ -11,6 +11,7 @@ dbt-databricks~=1.4.0
 dbt-trino~=1.4.0
 dbt-rpc~=0.1.1
 grpcio-status~=1.47.0
+pyarrow~=12.0.0,!=12.0.1
 pyasn1-modules~=0.2.1
 pyodbc==4.0.32 --no-binary pyodbc
 snowflake-connector-python~=3.0,!=3.0.4

--- a/release_creation/snapshot/requirements/v1.4.pre.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.4.pre.requirements.txt
@@ -12,6 +12,7 @@ dbt-databricks~=1.4.0b1
 dbt-trino~=1.4.0
 dbt-rpc~=0.1.3b1
 grpcio-status~=1.47.0
+pyarrow~=12.0.0,!=12.0.1
 pyasn1-modules~=0.2.1
 pyodbc==4.0.32 --no-binary pyodbc
 snowflake-connector-python~=3.0,!=3.0.4

--- a/release_creation/snapshot/requirements/v1.5.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.5.latest.requirements.txt
@@ -8,7 +8,7 @@ dbt-databricks~=1.5.0
 dbt-trino~=1.5.0
 dbt-rpc~=0.4.0
 grpcio-status~=1.47.0
-pyasn1-modules~=0.2.1
 pyarrow~=12.0.0,!=12.0.1
+pyasn1-modules~=0.2.1
 pyodbc==4.0.32 --no-binary pyodbc
 snowflake-connector-python~=3.0,!=3.0.4

--- a/release_creation/snapshot/requirements/v1.5.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.5.latest.requirements.txt
@@ -9,6 +9,6 @@ dbt-trino~=1.5.0
 dbt-rpc~=0.4.0
 grpcio-status~=1.47.0
 pyasn1-modules~=0.2.1
-pyarrow~=12.0.0
+pyarrow~=12.0.0,!=12.0.1
 pyodbc==4.0.32 --no-binary pyodbc
 snowflake-connector-python~=3.0,!=3.0.4

--- a/release_creation/snapshot/requirements/v1.5.latest.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.5.latest.requirements.txt
@@ -9,5 +9,6 @@ dbt-trino~=1.5.0
 dbt-rpc~=0.4.0
 grpcio-status~=1.47.0
 pyasn1-modules~=0.2.1
+pyarrow~=12.0.0
 pyodbc==4.0.32 --no-binary pyodbc
 snowflake-connector-python~=3.0,!=3.0.4

--- a/release_creation/snapshot/requirements/v1.5.pre.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.5.pre.requirements.txt
@@ -7,6 +7,7 @@ dbt-postgres~=1.5.0b1
 dbt-spark[PyHive,ODBC]~=1.5.0b1
 dbt-rpc~=0.1.3b1
 grpcio-status~=1.47.0
+pyarrow~=12.0.0,!=12.0.1
 pyasn1-modules~=0.2.1
 pyodbc==4.0.32 --no-binary pyodbc
 snowflake-connector-python~=3.0,!=3.0.4

--- a/release_creation/snapshot/requirements/v1.6.pre.requirements.txt
+++ b/release_creation/snapshot/requirements/v1.6.pre.requirements.txt
@@ -8,5 +8,6 @@ dbt-spark[PyHive,ODBC]~=1.6.0b2
 dbt-rpc~=0.4.1
 grpcio-status~=1.47.0
 pyasn1-modules~=0.2.1
+pyarrow~=12.0.0,!=12.0.1
 pyodbc==4.0.32 --no-binary pyodbc
 snowflake-connector-python~=3.0,!=3.0.4


### PR DESCRIPTION
pyarrow==12.0.1 was packaged with incorrect metadata, see: https://github.com/apache/arrow/issues/36065

Due to the way we download and install pip packages this throws off pip's validation mechanism. 
